### PR TITLE
Sailjail profile, improved downloader, and UI fixes

### DIFF
--- a/harbour-sailimgur.desktop
+++ b/harbour-sailimgur.desktop
@@ -4,3 +4,8 @@ X-Nemo-Application-Type=silica-qt5
 Name=Sailimgur
 Icon=harbour-sailimgur
 Exec=harbour-sailimgur
+
+[X-Sailjail]
+Permissions=Internet;Pictures
+OrganizationName=harbour-sailimgur
+ApplicationName=harbour-sailimgur

--- a/harbour-sailimgur.pro
+++ b/harbour-sailimgur.pro
@@ -5,7 +5,7 @@ DEFINES += APP_VERSION=\\\"$$VERSION\\\"
 DEFINES += APP_RELEASE=\\\"$$RELEASE\\\"
 
 # Qt Library
-QT += svg network multimedia
+QT += svg network multimedia concurrent
 
 appicons.path = /usr/share/icons/hicolor
 appicons.files = appicons/*

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -127,9 +127,18 @@ ApplicationWindow {
         }
     }
 
+    Connections {
+        target: sailimgurMgr
+
+        onSaveImageSucceeded: {
+            Notices.show(qsTr("Image saved as “%1”").arg(name), 5000, Notice.Bottom)
+        }
+        onErrorImageExists: {
+            Notices.show(qsTr("Image already saved as “%1”").arg(name), 5000, Notice.Bottom)
+        }
+    }
+
     Component.onCompleted: {
         settings.loadSettings();
     }
 }
-
-

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -133,8 +133,15 @@ ApplicationWindow {
         onSaveImageSucceeded: {
             Notices.show(qsTr("Image saved as “%1”").arg(name), 5000, Notice.Bottom)
         }
+        onSaveImageFailed: {
+            Notices.show(qsTr("Failed to download “%1”").arg(name), 5000, Notice.Bottom)
+        }
         onErrorImageExists: {
             Notices.show(qsTr("Image already saved as “%1”").arg(name), 5000, Notice.Bottom)
+        }
+        onErrorSavingDisabled: {
+            // TODO recommend to check the logs
+            Notices.show(qsTr("Saving images is not possible"), 5000, Notice.Bottom)
         }
     }
 

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -46,50 +46,15 @@ ApplicationWindow {
 
     AccountPage { id: accountPage; }
 
-    Rectangle {
-        id: infoBanner;
-        y: 4 * Theme.paddingMedium;
-        z: 1;
-        width: parent.width;
-
-        height: infoLabel.height + 2 * Theme.paddingMedium;
-        color: Theme.highlightBackgroundColor;
-        opacity: 0;
-        visible: false;
-
-        Label {
-            id: infoLabel;
-            text : ''
-            font.pixelSize: Screen.sizeCategory >= Screen.Large
-                                ? constant.fontSizeSmall : constant.fontSizeXSmall
-            width: parent.width - 2 * Theme.paddingSmall
-            anchors.top: parent.top;
-            anchors.topMargin: Theme.paddingMedium;
-            y: 4 * Theme.paddingMedium;
-            horizontalAlignment: Text.AlignHCenter;
-            wrapMode: Text.WrapAnywhere;
-
-            MouseArea {
-                anchors.fill: parent;
-                onClicked: {
-                    infoBanner.opacity = 0.0;
-                    infoBanner.visible = false;
-                }
-            }
-        }
+    QtObject {
+        id: infoBanner
 
         function showText(text) {
-            infoLabel.text = text;
-            opacity = 0.9;
-            infoBanner.visible = true;
-            //console.log("infoBanner: " + text);
-            closeTimer.restart();
+            Notices.show(text, 3000, Notice.Top)
         }
 
         function showError(errorMessage) {
-            infoLabel.text = errorMessage;
-            opacity = 0.9;
-            infoBanner.visible = true;
+            Notices.show(errorMessage, 3000, Notice.Center)
         }
 
         function showHttpError(errorCode, errorMessage) {
@@ -138,17 +103,6 @@ ApplicationWindow {
                     showError("Error: " + errorMessage + " (" + errorCode + ")");
             }
             */
-        }
-
-        Behavior on opacity { FadeAnimation {} }
-
-        Timer {
-            id: closeTimer;
-            interval: 3000;
-            onTriggered: {
-                infoBanner.opacity = 0.0;
-                infoBanner.visible = true;
-            }
         }
     }
 

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -1,3 +1,10 @@
+/*
+ * This file is part of harbour-sailimgur.
+ * SPDX-FileCopyrightText: 2025 Mirian Margiani
+ * SPDX-FileCopyrightText: 2014 Marko Wallin
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 import "pages"

--- a/qml/pages/GalleryContentDelegate.qml
+++ b/qml/pages/GalleryContentDelegate.qml
@@ -1,3 +1,10 @@
+/*
+ * This file is part of harbour-sailimgur.
+ * SPDX-FileCopyrightText: 2025 Mirian Margiani
+ * SPDX-FileCopyrightText: 2014 Marko Wallin
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 

--- a/qml/pages/GalleryContentDelegate.qml
+++ b/qml/pages/GalleryContentDelegate.qml
@@ -7,10 +7,21 @@ Item {
     property Item contextMenu;
     property bool menuOpen: contextMenu != null && contextMenu.parent === galleryContentDelegate;
     property string contextLink;
-    property bool savingInProgress: false;
     property int itemIndex;
     property bool isSlideshow: false;
     property int totalImages: 0;
+
+    readonly property string downloadUrl: {
+        if (type == String("image/gif")
+                && size
+                && size.indexOf("MiB") > -1
+                && parseInt(size.replace(" MiB", "")) > settings.maxGifSize) {
+            return mp4
+        } else {
+            return link_original
+        }
+    }
+    property bool savingInProgress: sailimgurMgr.isDownloading(downloadUrl)
 
     width: albumListView.width;
     height: galleryContainer.height;

--- a/qml/pages/ImageButtons.qml
+++ b/qml/pages/ImageButtons.qml
@@ -17,6 +17,7 @@ Row {
     IconButton {
         id: dlIcon
 
+        visible: sailimgurMgr.canDownload
         enabled: visible && !savingInProgress
 
         icon {
@@ -83,6 +84,8 @@ Row {
     Connections {
         target: sailimgurMgr
         onSaveImageSucceeded: if (url == downloadUrl) savingInProgress = false
+        onSaveImageFailed: if (url == downloadUrl) savingInProgress = false
         onErrorImageExists: if (url == downloadUrl) savingInProgress = false
+        onErrorSavingDisabled: if (url == downloadUrl) savingInProgress = false
     }
 }

--- a/qml/pages/ImageButtons.qml
+++ b/qml/pages/ImageButtons.qml
@@ -1,3 +1,10 @@
+/*
+ * This file is part of harbour-sailimgur.
+ * SPDX-FileCopyrightText: 2020-2025 Mirian Margiani
+ * SPDX-FileCopyrightText: 2014 Marko Wallin
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 import QtQuick 2.0
 import Sailfish.Silica 1.0
 

--- a/qml/pages/ImageButtons.qml
+++ b/qml/pages/ImageButtons.qml
@@ -2,7 +2,7 @@ import QtQuick 2.0
 import Sailfish.Silica 1.0
 
 Row {
-    property var iconSize: Theme.itemSizeSmall;
+    readonly property int iconSize: Theme.itemSizeSmall;
 
     height: iconSize + 2 * Theme.paddingMedium;
 
@@ -20,34 +20,20 @@ Row {
     }
 
     IconButton {
-        id: dlIcon;
-        icon.width: parent.iconSize;
-        icon.height: parent.iconSize;
-        icon.source: constant.iconSave;
+        id: dlIcon
 
-        visible: !savingInProgress
+        enabled: visible && !savingInProgress
+
+        icon {
+            width: parent.iconSize
+            height: parent.iconSize
+            source: savingInProgress ? constant.iconSaving : constant.iconSave
+        }
 
         onClicked: {
             savingInProgress = true;
-            if (type === "image/gif" && size && size.indexOf("MiB") > -1) {
-                var sizeNo = size.replace(" MiB", "");
-                if (parseInt(sizeNo) > settings.maxGifSize) {
-                    sailimgurMgr.saveImage(mp4);
-                } else {
-                    sailimgurMgr.saveImage(link_original);
-                }
-            } else {
-                sailimgurMgr.saveImage(link_original);
-            }
+            sailimgurMgr.saveImage(downloadUrl)
         }
-    }
-
-    IconButton {
-        icon.width: parent.iconSize;
-        icon.height: parent.iconSize;
-        icon.source: constant.iconSaving;
-
-        visible: savingInProgress;
     }
 
     IconButton {
@@ -107,15 +93,12 @@ Row {
                 infoBanner.showText("Image saved as " + name);
             }
             savingInProgress = false;
-            // FIXME: TypeError: Cannot read property of null
-//            dlIcon.icon.source = constant.iconSaveDone;
         }
         function errorImageExists(name) {
             if (infoBanner) {
                 infoBanner.showText("Image already saved as " + name);
             }
             savingInProgress = false;
-//            dlIcon.icon.source = constant.iconSaveDone;
         }
     }
 

--- a/qml/pages/ImageButtons.qml
+++ b/qml/pages/ImageButtons.qml
@@ -14,11 +14,6 @@ Row {
 
     spacing: Theme.paddingLarge;
 
-    Component.onCompleted: {
-        sailimgurMgr.saveImageSucceeded.connect(internal.saveImageSucceeded);
-        sailimgurMgr.errorImageExists.connect(internal.errorImageExists);
-    }
-
     IconButton {
         id: dlIcon
 
@@ -85,21 +80,9 @@ Row {
         }
     }
 
-    QtObject {
-        id: internal;
-
-        function saveImageSucceeded(name) {
-            if (infoBanner) {
-                infoBanner.showText("Image saved as " + name);
-            }
-            savingInProgress = false;
-        }
-        function errorImageExists(name) {
-            if (infoBanner) {
-                infoBanner.showText("Image already saved as " + name);
-            }
-            savingInProgress = false;
-        }
+    Connections {
+        target: sailimgurMgr
+        onSaveImageSucceeded: if (url == downloadUrl) savingInProgress = false
+        onErrorImageExists: if (url == downloadUrl) savingInProgress = false
     }
-
 }

--- a/src/sailimgur.cpp
+++ b/src/sailimgur.cpp
@@ -1,65 +1,117 @@
+/*
+ * This file is part of harbour-sailimgur.
+ * SPDX-FileCopyrightText: 2025 Mirian Margiani
+ * SPDX-FileCopyrightText: 2014 Marko Wallin
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #include "sailimgur.h"
 
+#include <QtConcurrent/QtConcurrentRun>
 #include <QStandardPaths>
+#include <QDir>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QFileInfo>
+#include <QEventLoop>
 #include <QDebug>
 
-Sailimgur::Sailimgur(QObject *parent):
-    QObject(parent),
-    mReply(0),
-    mImage(0) {
+Sailimgur::Sailimgur(QObject *parent) :
+    QObject(parent)
+{
     mPictureLocation = QStandardPaths::writableLocation(QStandardPaths::PicturesLocation);
-}
 
-Sailimgur::~Sailimgur() {
-    if (mImage) {
-        qDebug() << "Closing mImage";
-        mImage->close();
-
-        // if client was shut down during full image download
-        if (mImage->size() == 0) {
-            qDebug() << "Remove empty file";
-            mImage->remove();
-        }
-        delete mImage;
-        mImage = 0;
-    }
-}
-
-void Sailimgur::saveImage(const QString &path) {
-    QString name = path.split("/").last().split("@").first();
-    qDebug() << "Requested to save" << path << "to gallery" << mPictureLocation << "with name" << name;
-
-    if (QFile::exists(mPictureLocation + "/" + name)) {
-        qDebug() << "Image already saved to" << mPictureLocation << "as" << name;
-        emit errorImageExists(name);
-        return;
+    if (mPictureLocation.isEmpty()) {
+        qDebug() << "Saving disabled: no suitable data location found";
     } else {
-        mImage = new QFile;
-        mImage->setFileName(mPictureLocation + "/" + name);
+        mPictureLocation += "/Sailimgur";
 
-        QUrl imageUrl(path);
-        QNetworkRequest request;
-        request.setUrl(QUrl(imageUrl));
-        mReply = mManager.get(request);
-        connect(mReply, &QNetworkReply::finished,
-                this, &Sailimgur::onSaveImageFinished);
+        auto picsInfo = QFileInfo(mPictureLocation);
 
-        mImage->open(QIODevice::WriteOnly);
+        if (picsInfo.exists() && !picsInfo.isDir()) {
+            qDebug() << "Saving disabled: target is not a directory at" << mPictureLocation;
+            mPictureLocation = "";
+        } else if (!QDir().mkpath(mPictureLocation)) {
+            qDebug() << "Saving disabled: failed to create target directory at" << mPictureLocation;
+            mPictureLocation = "";
+        }
     }
+
+    mCanDownload = !mPictureLocation.isEmpty();
+    emit canDownloadChanged();
 }
 
-void Sailimgur::onSaveImageFinished() {
-    disconnect(mReply, &QNetworkReply::finished,
-            this, &Sailimgur::onSaveImageFinished);
-    if (!mReply->error()) {
-        qDebug() << "Saving file";
-        mImage->write(mReply->readAll());
-        mImage->close();
-        QString fname = mImage->fileName().split("/").last().split("@").first();
-        emit saveImageSucceeded(fname);
-        delete mImage;
-        mImage = 0;
+Sailimgur::~Sailimgur() {}
+
+bool Sailimgur::isDownloading(QString name)
+{
+    return mQueue.contains(name);
+}
+
+void Sailimgur::saveImage(const QString &url) {
+    if (mPictureLocation.isEmpty() || !QFileInfo(mPictureLocation).isDir()) {
+        emit errorSavingDisabled();
+        return;
     }
-    mReply->deleteLater();
-    mReply = 0;
+
+    if (isDownloading(url)) {
+        return;
+    }
+
+    QString name = url.split("/").last().split("@").first();
+    auto imageInfo = QFileInfo(mPictureLocation + "/" + name);
+    qDebug() << "Requested to save" << url << "to" << imageInfo.absoluteFilePath();
+
+    auto watcher = QSharedPointer<QFutureWatcher<bool>>(new QFutureWatcher<bool>());
+    connect(watcher.data(), &QFutureWatcher<bool>::finished, this, [this, url](){
+        qDebug() << "Removing" << url << "from download queue";
+        mQueue.remove(url);
+    });
+
+    auto future = QtConcurrent::run([this, imageInfo, name, url]() -> bool {
+        if (imageInfo.exists()
+                && imageInfo.isReadable()
+                && imageInfo.isFile()
+                && imageInfo.size() == 0) {
+            qDebug() << "Removing empty file" << imageInfo.absoluteFilePath();
+        } else if (imageInfo.exists()) {
+            qDebug() << "Image already saved to" << imageInfo.absoluteFilePath();
+            emit errorImageExists(name, url);
+            return false;
+        }
+
+        QNetworkAccessManager manager;
+        auto request = QNetworkRequest(QUrl(url));
+        auto* reply = manager.get(request);
+
+        QEventLoop loop;
+        connect(reply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+        loop.exec();
+
+        if (reply->error()) {
+            qDebug() << "Failed to download" << imageInfo.absoluteFilePath();
+            emit saveImageFailed(name, url);
+            return false;
+        }
+
+        QFile localFile(imageInfo.absoluteFilePath());
+
+        if (!localFile.open(QIODevice::WriteOnly)) {
+            qDebug() << "Failed to open" << imageInfo.absoluteFilePath() << "for saving";
+            emit saveImageFailed(name, url);
+            return false;
+        }
+
+        qDebug() << "Saving downloaded file" << imageInfo.absoluteFilePath();
+        const QByteArray sdata = reply->readAll();
+        localFile.write(sdata);
+        localFile.close();
+
+        emit saveImageSucceeded(name, url);
+        return true;
+    });
+
+    qDebug() << "Adding" << url << "to download queue";
+    watcher->setFuture(future);
+    mQueue.insert(url, watcher);
 }

--- a/src/sailimgur.h
+++ b/src/sailimgur.h
@@ -1,35 +1,43 @@
+/*
+ * This file is part of harbour-sailimgur.
+ * SPDX-FileCopyrightText: 2025 Mirian Margiani
+ * SPDX-FileCopyrightText: 2014 Marko Wallin
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
 #ifndef SAILIMGUR_H
 #define SAILIMGUR_H
 
 #include <QObject>
-#include <QNetworkAccessManager>
-#include <QNetworkRequest>
-#include <QNetworkReply>
-#include <QFile>
+#include <QHash>
+#include <QFutureWatcher>
 
 class Sailimgur: public QObject
 {
     Q_OBJECT
+    Q_PROPERTY(bool canDownload READ canDownload NOTIFY canDownloadChanged)
 
 public:
     Sailimgur(QObject *parent = 0);
     ~Sailimgur();
 
+    Q_INVOKABLE bool isDownloading(QString url);
+    Q_INVOKABLE void saveImage(const QString &url);
+
+    bool canDownload() { return mCanDownload; }
+
 private:
-    QNetworkAccessManager mManager;
-    QNetworkReply* mReply;
-    QFile* mImage;
     QString mPictureLocation;
+    bool mCanDownload {true};
+    QHash<QString, QSharedPointer<QFutureWatcher<bool>>> mQueue;
 
 signals:
-    void saveImageSucceeded(const QString &name);
-    void errorImageExists(const QString &name);
+    void saveImageSucceeded(const QString &name, const QString &url);
+    void saveImageFailed(const QString &name, const QString &url);
+    void errorImageExists(const QString &name, const QString &url);
+    void errorSavingDisabled();
 
-public slots:
-    void saveImage(const QString &path);
-
-public slots:
-    void onSaveImageFinished();
+    void canDownloadChanged();
 };
 
 #endif // SAILIMGUR_H


### PR DESCRIPTION
I added a bunch of changes in this PR that piled up locally. I hope it's ok for you if I mix all of this...

- added a Sailjail profile: only Internet and Pictures permissions are required
- refactored the downloading logic:
  - downloaded images are now saved in `~/Pictures/Sailimgur` instead of `~/Pictures`
  - it's now possible to download multiple things at once
  - downloads are properly queued and run simultaneously and asynchronously
  - fixes empty files piling up if the internet connection is patchy or if the app crashes
  - it's possible now to switch galleries while downloads are running
- simplified some code and replaced the custom info banner with system `Silica` `Notices`